### PR TITLE
feat: Implement responsive images for content and portfolio

### DIFF
--- a/sass/_images.scss
+++ b/sass/_images.scss
@@ -1,0 +1,28 @@
+// Responsive images
+.post-content img {
+  max-width: 100%;
+  height: auto;
+  display: block; // Removes extra space below images if they are inline by default
+  margin: 1em auto; // Adds some vertical spacing and centers the image
+}
+
+// Media query for mobile devices
+@media screen and (max-width: 768px) {
+  .post-content img {
+    // Adjust margins for smaller screens if necessary
+    // The base rule (max-width: 100%) already ensures images scale down.
+    // We can remove horizontal auto margins if we want images to be full-width by default on mobile.
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
+// Responsive styles for images with the class .thumbnail
+// These are used in templates/portfolio.html
+img.thumbnail {
+  max-width: 100%;
+  height: auto;
+  display: block; // Ensures proper block-level behavior for margin auto and scaling
+  margin-left: auto; // Centers the image if its max-width is less than container width
+  margin-right: auto; // Centers the image
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -1,4 +1,5 @@
 @import
         "_main",
-        "_base"
+        "_base",
+        "_images"
 ;


### PR DESCRIPTION
This change introduces responsive behavior for images within the Zola theme.

Key changes:
- Created a new SCSS partial `sass/_images.scss` and imported it into the main `sass/style.scss`.
- Added CSS rules to make images within content areas (`.post-content img`) responsive. These images will now scale with the viewport, maintaining their aspect ratio (`max-width: 100%; height: auto;`). Margins are adjusted for mobile.
- Added CSS rules for portfolio thumbnail images (`img.thumbnail`) to also be responsive (`max-width: 100%; height: auto;`).

Behavior Notes:
- General images inserted via Markdown into posts or pages will now resize fluidly.
- Portfolio thumbnail images (`img.thumbnail`) will also resize fluidly. However, they are contained within a `div.thumbnail` which has a fixed height of 180px and `overflow: hidden`. This means the image, while responsive, may be vertically cropped by its container, which is part of the existing theme design.
- Images used in specific gallery-like layouts in content files (e.g., within `.row > .col` structures as seen in `content/2024-05-15-images.md`) have pre-existing theme styles that give them a fixed height (e.g., 275px) and use `object-fit: cover`. These images will be responsive in width but will maintain their fixed height and be cropped, as per the theme's design for such layouts.

Zola's automatic SCSS compilation will process these changes.